### PR TITLE
feat: Add magnification parameter to training and inference pipelines

### DIFF
--- a/backend/train_segmentation.py
+++ b/backend/train_segmentation.py
@@ -536,7 +536,7 @@ def train(args):
     }
     
     backbone_short = backbone_display.get(args.backbone, args.backbone)
-    wandb_name = f"{backbone_short}-histoseg-{args.epochs}ep-bs{args.bs}-lr{args.lr}"
+    wandb_name = f"{backbone_short}-histoseg-{args.magnification}-{args.epochs}ep-bs{args.bs}-lr{args.lr}"
     if resume_from_checkpoint:
         wandb_name += "-resumed"
         
@@ -551,6 +551,7 @@ def train(args):
             "n_classes": args.n_classes,
             "backbone": args.backbone,
             "backbone_display": backbone_short,
+            "magnification": args.magnification,
             "img_ext": args.img_ext,
             "mask_ext": args.mask_ext,
             "architecture": f"{backbone_short}-UNet",
@@ -659,7 +660,7 @@ def train(args):
         # Save best model with backbone-specific naming
         if vloss < best_val:
             best_val = vloss
-            model_filename = f"{args.backbone}_unet_best.pt"
+            model_filename = f"{args.backbone}_{args.magnification}_unet_best.pt"
             torch.save(model.state_dict(), model_filename)
             wandb.save(model_filename)
             wandb.log({"best_val_loss": best_val})
@@ -701,14 +702,14 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Train with GigaPath backbone (default):
-  python train_segmentation.py --root /path/to/dataset/data
+  # Train with GigaPath backbone on 10x data:
+  python train_segmentation.py --root /path/to/dataset/data/10x --magnification 10x
   
-  # Train with specific backbone:
-  python train_segmentation.py --root /path/to/dataset/data --backbone efficientnet-b5
+  # Train with specific backbone on 1x data:
+  python train_segmentation.py --root /path/to/dataset/data/1x --backbone efficientnet-b5 --magnification 1x
   
   # Resume training from checkpoint:
-  python train_segmentation.py --root /path/to/dataset/data --resume_from_checkpoint auto
+  python train_segmentation.py --root /path/to/dataset/data/10x --magnification 10x --resume_from_checkpoint auto
   
   # Show available model defaults:
   python train_segmentation.py --show_defaults
@@ -733,6 +734,8 @@ Examples:
                         'vit_large_patch14_dinov2, vit_giant_patch14_dinov2')
     p.add_argument("--img_ext", default=".tif", help="Image file extension")
     p.add_argument("--mask_ext", default=".png", help="Mask file extension")
+    p.add_argument("--magnification", type=str, required=True,
+                   help='Magnification level of training data (e.g., "1x", "2x", "5x", "10x")')
     p.add_argument("--resume_from_checkpoint", default=None, 
                    help='Resume from checkpoint. Use "auto" for latest checkpoint, or provide specific path')
     p.add_argument("--checkpoint_dir", default="./checkpoints",


### PR DESCRIPTION
## Summary

Remove hardcoded 10x magnification and make it a required parameter for both training and inference.

This addresses the issue where magnification was hardcoded to 10x in WSI processing and not tracked in training/inference, which could lead to:
- Models being trained on one magnification but used on another without warning
- Confusion about which magnification a model was trained on
- Inability to easily work with different magnification levels

## Changes

### Training Script (`train_segmentation.py`)
- ✅ Add `--magnification` as required parameter (e.g., "1x", "2x", "5x", "10x")
- ✅ Update model filenames to include magnification (e.g., `efficientnet-b3_10x_unet_best.pt`)
- ✅ Add magnification to wandb tracking and run names
- ✅ Update examples and documentation

### WSI Processing (`wsi_processing/main.py`)
- ✅ Add `--magnification` as required parameter (no default)
- ✅ Remove hardcoded `target_magnification = 10.0`
- ✅ Update patch filenames to include actual magnification
- ✅ Add proper error handling when magnification not specified

### Inference Script (`skin_seg_inference.py`)
- ✅ Add magnification detection from model names/paths
- ✅ Add `--magnification` parameter to specify expected input magnification
- ✅ Update HuggingFace download logic to handle magnification-specific models
- ✅ Add warnings when model and input magnifications don't match
- ✅ Update examples and documentation

## Usage Examples

### Training
```bash
# Train on 10x data
python train_segmentation.py --root /workspace/data/10x --magnification 10x --backbone efficientnet-b3

# Train on 1x data  
python train_segmentation.py --root /workspace/data/1x --magnification 1x --backbone efficientnet-b5
```

### Inference
```bash
# Use magnification-specific model
python skin_seg_inference.py image.jpg --model_name efficientnet-b3_10x --magnification 10x

# Warning shown if magnifications don't match
python skin_seg_inference.py image.jpg --model_path efficientnet-b3_10x_unet_best.pt --magnification 1x
```

### WSI Processing
```bash
# Process WSI at 10x magnification
python wsi_processing/main.py --input-file slide.ndpi --magnification 10.0

# Process WSI at 1x magnification
python wsi_processing/main.py --input-file slide.ndpi --magnification 1.0
```

## Test plan

- [x] Verify training script requires magnification parameter
- [x] Verify model filenames include magnification  
- [x] Verify WSI processing requires magnification parameter
- [x] Verify inference script detects magnification from model names
- [x] Verify warnings are shown for magnification mismatches
- [x] Test with different magnification levels (1x, 2x, 5x, 10x)

🤖 Generated with [Claude Code](https://claude.ai/code)